### PR TITLE
fix: change timeout for curl to download contrast agent

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -21,7 +21,7 @@ RUN apk update && apk add ca-certificates && update-ca-certificates && apk add o
 RUN apk update; apk add curl
 RUN wget https://github.com/WebGoat/WebGoat/releases/download/7.1/webgoat-container-7.1-exec.jar -O /opt/app/webgoat.jar
 
-RUN curl --max-time 20 $CONTRAST__BASEURL/agents/default/JAVA -H API-Key:$APIKey -H Authorization:$Auth -o /opt/contrast/contrast.jar
+RUN curl --max-time 900 $CONTRAST__BASEURL/agents/default/JAVA -H API-Key:$APIKey -H Authorization:$Auth -o /opt/contrast/contrast.jar
 
 EXPOSE 8080
 


### PR DESCRIPTION
Having some Internet troubles downloading the agent during the Contrast training on Jan 22, 2021. I changed the timeout for the curl request to 15 mins to allow for slower connections.