### PR TITLE
:lock: Migrate Sensitive Environment Variables to Container Runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,77 @@
+# Docker Env
+.env
+
+# MacOS
+
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+
+# Linux
+
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+
+# Windows
+
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+

--- a/CESetup.md
+++ b/CESetup.md
@@ -1,13 +1,8 @@
-
 # JUMPSTART DEVSECOPS and SECURITY OBSERVABILITY - for FREE - with the Contrast Community Edition, WebGoat, and Docker
 
 ## Got a little Docker experience? This will be easy.
 
 CLONE THIS REPO (or just grab all the files)
-
-	- Create a working directory
-	- Stash everything there
-	- Make a backup copy of the Dockerfile
 
 SIGN UP FOR A Contrast Community Edition Account [here](https://bit.ly/341PrFu)
 	- Check your email for confirmation
@@ -44,9 +39,14 @@ GET READY…
 
 <img src="img/CESetup7.png" width=500px />
 
-	- Click Profile on the left. Plug the Organization ID, Authorization Header, and API Key from the Profile page into the proper locations in the Dockerfile
-  	- Note: this is not best practice but we want to be expedient
-	- Doublecheck for correctness!
+Click Profile on the left. Copy the API Key, Service Key, and User Name from the
+Profile page to the `./Docker/.env` file like so:
+
+```
+CONTRAST__API__USER_NAME=<your-user-name>
+CONTRAST__API__API_KEY=<your-api-key>
+CONTRAST__API__SERVICE_KEY=<your-service-key>
+```
 
 GET SET…
 
@@ -56,9 +56,9 @@ GET SET…
 
 GO!
 
-% docker build \`pwd\` \-t dockerwebgoat
-
-% docker run \-\-rm –p 8080:8080 –t dockerwebgoat
+```shell
+docker-compose run --rm webgoat
+```
 
 <img src="img/CESetup10.png" width=500px />
 

--- a/Docker/Build
+++ b/Docker/Build
@@ -1,1 +1,0 @@
-docker build `pwd` -t dockerwebgoat

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,32 +1,33 @@
 # Dockerfile to run WebGoat 7.1 with Contrast Security
+FROM adoptopenjdk/openjdk8:debianslim
 
-FROM anapsix/alpine-java:jdk8
 
-# TODO Edit the following 3 lines and substitute the keys from your Contrast Security Your Account page
+# Install WebGoat
+# we do not use the WebGoat Docker image because it is based on Debian Jessie which is end of life
+ADD https://github.com/WebGoat/WebGoat/releases/download/7.1/webgoat-container-7.1-exec.jar /opt/webgoat/webgoat-container-7.1-exec.jar
 
-ENV OrgID=<Replace with your Organization ID>
-
-ENV Auth=<Replace with your Authorization Header>
-
-ENV APIKey=<Replace with your API Key>
-
-# End TODO
 
 # If you are using our Community Edition, this URL is what you need. If you already have a Contrast account or
 # you are in a formal evaluation with us, change the resource name (the ce.contrastsecurity.com portion of the URL)
 # to reflect your Contrast TeamServer
+ENV CONTRAST__API__URL=https://ce.contrastsecurity.com/Contrast
 
-ENV CONTRAST__BASEURL=https://ce.contrastsecurity.com/Contrast/api/ng/$OrgID
 
-RUN mkdir /opt/app
-RUN mkdir /opt/contrast
+# Install Contrast agent
+RUN apt-get update \
+  && apt-get install -y gnupg \
+  && curl https://pkg.contrastsecurity.com/api/gpg/key/public | apt-key add - \
+  && echo "deb https://pkg.contrastsecurity.com/debian-public/ all contrast" > /etc/apt/sources.list.d/contrast-all.list \
+  && apt-get update \
+  && apt-get install -y contrast-java-agent
 
-RUN apk update && apk add ca-certificates && update-ca-certificates && apk add openssl
-RUN apk update; apk add curl
-RUN wget https://github.com/WebGoat/WebGoat/releases/download/7.1/webgoat-container-7.1-exec.jar -O /opt/app/webgoat.jar
 
-RUN curl --max-time 20 $CONTRAST__BASEURL/agents/default/JAVA -H API-Key:$APIKey -H Authorization:$Auth -o /opt/contrast/contrast.jar
+# Configure Contrast for WebGoat
+ENV CONTRAST__AGENT__JAVA__STANDALONE_APP_NAME=WebGoatDocker \
+  CONTRAST__PROTECT__RULES__SQL_INJECTION__DETECT_TAUTOLOGIES=true \
+  CONTRAST__SERVER__NAME=WebGoatDockerServer \
+  CONTRAST__AGENT__LOGGER__STDERR=true
 
 EXPOSE 8080
 
-CMD ["java","-javaagent:/opt/contrast/contrast.jar","-Dcontrast.standalone.appname=WebGoatDocker","-Dcontrast.protect.rules.sql-injection.detect_tautologies=true","-Dcontrast.server=WebGoatDockerServer","-jar","/opt/app/webgoat.jar"]
+CMD ["java","-javaagent:/opt/contrast/contrast-agent.jar","-jar","/opt/webgoat/webgoat-container-7.1-exec.jar"]

--- a/Docker/Run
+++ b/Docker/Run
@@ -1,1 +1,0 @@
-docker run --rm -p 8080:8080 -t dockerwebgoat

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.9'
+services:
+  webgoat:
+    build: .
+    environment:
+      - CONTRAST__API__API_KEY
+      - CONTRAST__API__SERVICE_KEY
+      - CONTRAST__API__USER_NAME
+    ports:
+      - "8080:8080"

--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker-compose run --rm webgoat


### PR DESCRIPTION
* use docker-compose to reduce the number of Docker commands the user has to run from 2 to 1
* use standard docker-compose .env file for secure environment variables
* add .gitignore for the .env file (and OS files) to avoid checking in secrets
* use contrast-java-agent Debian package instead of cURL + TeamServer to avoid leaking credentials in the cURL command
* configure Contrast logging to stderr so that it is visible in docker logs